### PR TITLE
Make compatible and render multiline strings

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,8 +10,8 @@
         "PrintAny"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.5 <= v < 5.0.0",
-        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "4.0.5 <= v < 6.0.0",
+        "elm-lang/html": "1.1.0 <= v < 3.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/PrintAny.elm
+++ b/src/PrintAny.elm
@@ -171,7 +171,7 @@ viewLine (Config config) ( indent, string ) =
             , ( "marginBottom", "0px" )
             ]
         ]
-        [ text string ]
+        [ text <| String.join "\n" <| String.split "\\n" string ]
 
 
 {-| Prints a stylized version of any record to the DOM.


### PR DESCRIPTION
I updated the version range for core and html, so it works with current versions. I tested it manually once and it worked.

Also I noticed multiline strings were rendered escaped:
```
"abc\ndef"
```

I changed it into
```
"abc
def"
```
because otherwise the output in my case was not readable at all. Since this is considered a debugging tool I think it is a good idea in general.

